### PR TITLE
feat: multi machines support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config.json
 build/
 .idea
+wakebot_go

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${fileDirname}",
+            "args": ["--config", "config.json"]
+        }
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+BINARY_NAME=wakebot_go
+GO_FILES=$(shell find . -name '*.go')
+
+.PHONY: all build clean run test help release
+
+all: build
+
+build:
+	go build -o $(BINARY_NAME)
+
+release:
+	@echo "Building for release..."
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-s -w --extldflags "-static"' -o $(BINARY_NAME) .
+	@echo "Build complete: $(BINARY_NAME)"
+
+run: build
+	./$(BINARY_NAME)
+
+test:
+	go test -v ./...
+
+clean:
+	go clean
+	rm -f $(BINARY_NAME)
+
+help:
+	@echo "Usage:"
+	@echo "  make build   - Build the binary"
+	@echo "  make release - Build a statically linked and stripped binary for release"
+	@echo "  make run     - Build and run the application"
+	@echo "  make test    - Run tests"
+	@echo "  make clean   - Remove binary and build artifacts"
+

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ This program run as a Telegram Bot and waiting user to input command to help you
 | `/wake` | Send Magic packet (WOL) to target Machine |
 | `/check` | Check Whether the machine is up or not, by sending `ping` to its IP |
 | `/hello` | Just say "Hi", to make sure that bot is running property |
+| `/list`  | Show the list of available machine |
 
 Best fit when you are having a running 24/7 tiny machine likes Raspberry Pi or any embedded Platform which supports Linux and Go.
 
-**Requires Go 1.20**.
+**Requires Go 1.20 and up**.
 
 **Note**:
 
@@ -35,9 +36,13 @@ See `config.json.template` -> Rename it to `config.json` and edit content, place
 | `bot_token`      | Telegram bot token                                                                                                                                                                                                       |
 | `chat_id`        | Who's the bot owner?                                                                                                                                                                                                     |
 | `wol_passwd`     | Password to send to remote target, if authentication is set                                                                                                                                                              |
+| `targets` | List of targets host machine, each target contains: `name`, `mac`, `ip` |
+
+**
 
 **TODO**:
 
 - <s>Support WOL with Password</s>
+- <s>Support multiple machines</s>
 - Support Remote Shutdown
 - ...

--- a/config.json.template
+++ b/config.json.template
@@ -3,6 +3,13 @@
   "remote_mac": "Remote Mac addr",
   "wol_passwd": "WOL Password (if any)",
   "inet_interface": "eth0 (work on *nix for Raw Packet)",
+  "targets": [
+    {
+      "name": "Machine name",
+      "mac": "AA:BB:CC:DD:EE:FF",
+      "ip": "Remote IP Goes here:Port (normally 7 or 9 in UDP Mode)"
+    }
+  ],
   "bot_token": "Telegram's bot token",
   "chat_id": 0,
   "api_endpoint": "https://api.telegram.org/bot%s/%s"


### PR DESCRIPTION
add `Makefile`

## Summary by Sourcery

Add multi-machine support to the Telegram wake-on-LAN bot, including interactive machine selection, listing, and build tooling improvements.

New Features:
- Allow configuring and targeting multiple machines via a new targets list in the config and interactive Telegram keyboard selection
- Add a /list command to show available configured machines

Enhancements:
- Refactor wake-on-LAN logic into a reusable helper and improve ping handling to support host:port formats

Build:
- Introduce a Makefile with build, release, run, test, and clean targets

Documentation:
- Document multi-machine configuration, the new /list command, and update Go version requirements in the README